### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM swiftdocker/swift
+
+ENV CPL_WS /opt/cpl
+COPY . CPL_WS
+WORKDIR CPL_WS
+
+RUN ./build.sh install


### PR DESCRIPTION
To use, install docker:
`curl -sSL https://get.docker.com/ | sh`
Then build an image from the Dockerfile in the project directory:
`docker build -t cpl .`
I think your build script is not checking if sudo is necessary:

``` terminal
.../cpl$ docker build -t cpl .
Sending build context to Docker daemon 410.1 kB
Step 1 : FROM swiftdocker/swift
 ---> 21f2109b7eef
Step 2 : ENV CPL_WS /opt/cpl
 ---> Running in 99623d8f1b38
 ---> 84aa30fa329f
Removing intermediate container 99623d8f1b38
Step 3 : COPY . CPL_WS
 ---> a57c3179898b
Removing intermediate container f2439d34286a
Step 4 : WORKDIR CPL_WS
 ---> Running in 6f8f172faf97
 ---> af5cb90a1c3f
Removing intermediate container 6f8f172faf97
Step 5 : RUN ./build.sh install
 ---> Running in d9c1b9784810
Building C Sources		[PASS]
Building Swift Sources		[PASS]
Installing to /usr/bin/cpl		./build.sh: line 27: sudo: command not found
[FAIL]
Aborting Install...
 ---> ae147eb5c25b
Removing intermediate container d9c1b9784810
Successfully built ae147eb5c25b

```